### PR TITLE
Catch message handler errors only if the channel isn't closed

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Add/register a message type for a certain encoding. Options include:
   // Called when the remote side sends a message.
   // Errors here are caught and forwared to stream.destroy,
   // unless the channel has already closed, in which case the stream
-  // is left alone but the error is rethrown
+  // is left alone but the error is emitted via the `warning` event
   async onmessage (message) { }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -133,7 +133,9 @@ Add/register a message type for a certain encoding. Options include:
   // compact-encoding specifying how to encode/decode this message
   encoding: c.binary,
   // Called when the remote side sends a message.
-  // Errors here are caught and forwared to stream.destroy
+  // Errors here are caught and forwared to stream.destroy,
+  // unless the channel has already closed, in which case the stream
+  // is left alone but the error is rethrown
   async onmessage (message) { }
 }
 ```

--- a/index.js
+++ b/index.js
@@ -48,8 +48,7 @@ class Channel {
     this._extensions = null
 
     this._decBound = this._dec.bind(this)
-    this._decAndDestroyBound = this._decAndMaybeDestroy.bind(this, false)
-    this._decAndMaybeDestroyBound = this._decAndMaybeDestroy.bind(this, true)
+    this._decAndMaybeDestroyBound = this._decAndMaybeDestroy.bind(this)
 
     this._openedPromise = null
     this._openedResolve = null
@@ -120,9 +119,9 @@ class Channel {
     if (--this._active === 0 && this.closed === true) this._destroy()
   }
 
-  _decAndMaybeDestroy(maybeDestroy, err) {
+  _decAndMaybeDestroy(err) {
     this._dec()
-    if (maybeDestroy && this.closed) return this._mux._warn(err)
+    if (this.closed) return this._mux._warn(err)
     this._mux._safeDestroy(err)
   }
 
@@ -182,13 +181,10 @@ class Channel {
     this._mux._resumeMaybe()
   }
 
-  _track(p, maybeDestroy) {
+  _track(p) {
     if (isPromise(p) === true) {
       this._active++
-      return p.then(
-        this._decBound,
-        maybeDestroy ? this._decAndMaybeDestroyBound : this._decAndDestroyBound
-      )
+      return p.then(this._decBound, this._decAndMaybeDestroyBound)
     }
 
     return null
@@ -278,7 +274,7 @@ class Channel {
       encoding,
       onmessage,
       recv(state, session) {
-        return session._track(m.onmessage(encoding.decode(state), session), true)
+        return session._track(m.onmessage(encoding.decode(state), session))
       },
       send(m, session = s) {
         if (session.closed === true) return false

--- a/index.js
+++ b/index.js
@@ -185,7 +185,10 @@ class Channel {
   _track(p, maybeDestroy) {
     if (isPromise(p) === true) {
       this._active++
-      return p.then(this._decBound, maybeDestroy ? this._decAndMaybeDestroyBound : this._decAndDestroyBound)
+      return p.then(
+        this._decBound,
+        maybeDestroy ? this._decAndMaybeDestroyBound : this._decAndDestroyBound
+      )
     }
 
     return null

--- a/index.js
+++ b/index.js
@@ -122,7 +122,7 @@ class Channel {
 
   _decAndMaybeDestroy(maybeDestroy, err) {
     this._dec()
-    if (maybeDestroy && this.closed) throw err
+    if (maybeDestroy && this.closed) return this._mux._warn(err)
     this._mux._safeDestroy(err)
   }
 
@@ -822,6 +822,11 @@ module.exports = class Protomux {
     safetyCatch(err)
     this._destroying = true
     this.stream.destroy(err)
+  }
+
+  _warn(err) {
+    safetyCatch(err)
+    this.stream.emit('warning', err)
   }
 
   _shutdown() {

--- a/index.js
+++ b/index.js
@@ -48,7 +48,8 @@ class Channel {
     this._extensions = null
 
     this._decBound = this._dec.bind(this)
-    this._decAndDestroyBound = this._decAndDestroy.bind(this)
+    this._decAndDestroyBound = this._decAndMaybeDestroy.bind(this, false)
+    this._decAndMaybeDestroyBound = this._decAndMaybeDestroy.bind(this, true)
 
     this._openedPromise = null
     this._openedResolve = null
@@ -119,8 +120,9 @@ class Channel {
     if (--this._active === 0 && this.closed === true) this._destroy()
   }
 
-  _decAndDestroy(err) {
+  _decAndMaybeDestroy(maybeDestroy, err) {
     this._dec()
+    if (maybeDestroy && this.closed) throw err
     this._mux._safeDestroy(err)
   }
 
@@ -180,10 +182,10 @@ class Channel {
     this._mux._resumeMaybe()
   }
 
-  _track(p) {
+  _track(p, maybeDestroy) {
     if (isPromise(p) === true) {
       this._active++
-      return p.then(this._decBound, this._decAndDestroyBound)
+      return p.then(this._decBound, maybeDestroy ? this._decAndMaybeDestroyBound : this._decAndDestroyBound)
     }
 
     return null
@@ -273,7 +275,7 @@ class Channel {
       encoding,
       onmessage,
       recv(state, session) {
-        return session._track(m.onmessage(encoding.decode(state), session))
+        return session._track(m.onmessage(encoding.decode(state), session), true)
       },
       send(m, session = s) {
         if (session.closed === true) return false

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "brittle": "^3.0.0",
     "lunte": "^1.0.0",
     "prettier": "^3.6.2",
-    "prettier-config-holepunch": "^2.0.0"
+    "prettier-config-holepunch": "^2.0.0",
+    "uncaughts": "^1.1.3"
   },
   "scripts": {
     "format": "prettier --write .",

--- a/test.js
+++ b/test.js
@@ -3,7 +3,6 @@ const SecretStream = require('@hyperswarm/secret-stream')
 const test = require('brittle')
 const c = require('compact-encoding')
 const b4a = require('b4a')
-const uncaughts = require('uncaughts')
 
 test('basic', function (t) {
   const a = new Protomux(new SecretStream(true))
@@ -680,11 +679,6 @@ test('async onmessage rejecting after channel close does not destroy the stream'
   t.plan(2)
 
   let error = null
-  const uncaughtHandler = (err) => {
-    t.is(err, error, 'error was uncaught')
-  }
-  uncaughts.on(uncaughtHandler)
-  t.teardown(() => uncaughts.off(uncaughtHandler))
 
   const a = new Protomux(new SecretStream(true))
   const b = new Protomux(new SecretStream(false))
@@ -694,6 +688,9 @@ test('async onmessage rejecting after channel close does not destroy the stream'
   let streamDestroyed = false
   a.stream.on('error', function () {
     t.fail('a stream errored')
+  })
+  a.stream.on('warning', function (err) {
+    t.is(err, error, 'the stream warned the error')
   })
   a.stream.on('close', function () {
     streamDestroyed = true

--- a/test.js
+++ b/test.js
@@ -3,6 +3,7 @@ const SecretStream = require('@hyperswarm/secret-stream')
 const test = require('brittle')
 const c = require('compact-encoding')
 const b4a = require('b4a')
+const uncaughts = require('uncaughts')
 
 test('basic', function (t) {
   const a = new Protomux(new SecretStream(true))
@@ -674,6 +675,112 @@ test('incoming onopen runs after the pair callback finishes', function (t) {
     t.ok(opened, 'onopen fired after the pair callback finished')
   })
 })
+
+test('async onmessage rejecting after channel close does not destroy the stream', async function (t) {
+  t.plan(2)
+
+  let error = null
+  const uncaughtHandler = (err) => {
+    t.is(err, error, 'error was uncaught')
+  }
+  uncaughts.on(uncaughtHandler)
+  t.teardown(() => uncaughts.off(uncaughtHandler))
+
+  const a = new Protomux(new SecretStream(true))
+  const b = new Protomux(new SecretStream(false))
+
+  replicate(a, b)
+
+  let streamDestroyed = false
+  a.stream.on('error', function () {
+    t.fail('a stream errored')
+  })
+  a.stream.on('close', function () {
+    streamDestroyed = true
+  })
+
+  let rejectMessage = null
+  let handlerReady = null
+  const received = new Promise((resolve) => {
+    handlerReady = resolve
+  })
+
+  const aChannel = a.createChannel({ protocol: 'foo' })
+  aChannel.open()
+  aChannel.addMessage({
+    encoding: c.string,
+    onmessage() {
+      return new Promise((_, reject) => {
+        rejectMessage = reject
+        handlerReady()
+      })
+    }
+  })
+
+  const bc = b.createChannel({ protocol: 'foo' })
+  bc.open()
+  bc.addMessage({ encoding: c.string }).send('hello')
+
+  await received
+
+  aChannel.close()
+  error = new Error('boom')
+  rejectMessage(error)
+
+  await new Promise((resolve) => setTimeout(resolve, 50))
+
+  t.absent(streamDestroyed, 'stream was not destroyed after the channel closed')
+})
+
+test('async onmessage rejecting while channel is open still destroys the stream', async function (t) {
+  t.plan(2)
+
+  const a = new Protomux(new SecretStream(true))
+  const b = new Protomux(new SecretStream(false))
+
+  replicate(a, b)
+
+  let error = null
+  let streamDestroyed = false
+  a.stream.on('error', function (err) {
+    t.is(err, error, 'stream got error')
+  })
+  a.stream.on('close', function () {
+    streamDestroyed = true
+  })
+
+  let rejectMessage = null
+  let handlerReady = null
+  const received = new Promise((resolve) => {
+    handlerReady = resolve
+  })
+
+  const ac = a.createChannel({ protocol: 'foo' })
+  ac.open()
+  ac.addMessage({
+    encoding: c.string,
+    onmessage() {
+      return new Promise((_, reject) => {
+        rejectMessage = reject
+        handlerReady()
+      })
+    }
+  })
+
+  const bc = b.createChannel({ protocol: 'foo' })
+  bc.open()
+  bc.addMessage({ encoding: c.string }).send('hello')
+
+  await received
+
+  error = new Error('boom')
+  rejectMessage(error)
+
+  await new Promise((resolve) => setTimeout(resolve, 50))
+
+  t.ok(streamDestroyed, 'stream was destroyed while the channel was still open')
+})
+
 function replicate(a, b) {
   a.stream.rawStream.pipe(b.stream.rawStream).pipe(a.stream.rawStream)
 }

--- a/test.js
+++ b/test.js
@@ -933,7 +933,7 @@ test('async ondestroy rejecting emits a warning instead of destroying the stream
   t.absent(streamDestroyed, 'stream was not destroyed after the channel closed')
 })
 
-test.solo('async ondrain rejecting after channel close does not destroy the stream', async function (t) {
+test('async ondrain rejecting after channel close does not destroy the stream', async function (t) {
   t.plan(2)
 
   let error = null

--- a/test.js
+++ b/test.js
@@ -778,6 +778,221 @@ test('async onmessage rejecting while channel is open still destroys the stream'
   t.ok(streamDestroyed, 'stream was destroyed while the channel was still open')
 })
 
+test('async onopen rejecting after channel close does not destroy the stream', async function (t) {
+  t.plan(2)
+
+  let error = null
+
+  const a = new Protomux(new SecretStream(true))
+  const b = new Protomux(new SecretStream(false))
+
+  replicate(a, b)
+
+  let streamDestroyed = false
+  b.stream.on('error', function () {
+    t.fail('b stream errored')
+  })
+  b.stream.on('warning', function (err) {
+    t.is(err, error, 'the stream warned the error')
+  })
+  b.stream.on('close', function () {
+    streamDestroyed = true
+  })
+
+  const protocol = 'foo'
+
+  let rejectOpen = null
+  let handlerReady = null
+  const opened = new Promise((resolve) => {
+    handlerReady = resolve
+  })
+
+  let bc = null
+  b.pair({ protocol }, () => {
+    bc = b.createChannel({
+      protocol,
+      onopen() {
+        return new Promise((_, reject) => {
+          rejectOpen = reject
+          handlerReady()
+        })
+      }
+    })
+    bc.open()
+  })
+
+  a.createChannel({ protocol }).open()
+
+  await opened
+
+  bc.close()
+  error = new Error('boom')
+  rejectOpen(error)
+
+  await new Promise(setImmediate)
+
+  t.absent(streamDestroyed, 'stream was not destroyed after the channel closed')
+})
+
+test('async onclose rejecting emits a warning instead of destroying the stream', async function (t) {
+  t.plan(3)
+
+  let error = null
+
+  const a = new Protomux(new SecretStream(true))
+  const b = new Protomux(new SecretStream(false))
+
+  replicate(a, b)
+
+  let streamDestroyed = false
+  a.stream.on('error', function () {
+    t.fail('a stream errored')
+  })
+  a.stream.on('warning', function (err) {
+    t.is(err, error, 'the stream warned the error')
+  })
+  a.stream.on('close', function () {
+    streamDestroyed = true
+  })
+
+  let rejectClose = null
+  const ac = a.createChannel({
+    protocol: 'foo',
+    onclose() {
+      return new Promise((_, reject) => {
+        rejectClose = reject
+      })
+    }
+  })
+  ac.open()
+
+  const bc = b.createChannel({ protocol: 'foo' })
+  bc.open()
+
+  // give the channel a chance to fully open before closing it
+  await new Promise(setImmediate)
+  t.ok(ac.opened, 'a is opened')
+
+  ac.close()
+  error = new Error('boom')
+  rejectClose(error)
+
+  // Allow warning to propagate
+  await new Promise(setImmediate)
+
+  t.absent(streamDestroyed, 'stream was not destroyed after the channel closed')
+})
+
+test('async ondestroy rejecting emits a warning instead of destroying the stream', async function (t) {
+  t.plan(3)
+
+  let error = null
+
+  const a = new Protomux(new SecretStream(true))
+  const b = new Protomux(new SecretStream(false))
+
+  replicate(a, b)
+
+  let streamDestroyed = false
+  a.stream.on('error', function () {
+    t.fail('a stream errored')
+  })
+  a.stream.on('warning', function (err) {
+    t.is(err, error, 'the stream warned the error')
+  })
+  a.stream.on('close', function () {
+    streamDestroyed = true
+  })
+
+  let rejectDestroy = null
+  const ac = a.createChannel({
+    protocol: 'foo',
+    ondestroy() {
+      return new Promise((_, reject) => {
+        rejectDestroy = reject
+      })
+    }
+  })
+  ac.open()
+
+  const bc = b.createChannel({ protocol: 'foo' })
+  bc.open()
+
+  // give the channel a chance to fully open before closing it
+  await new Promise(setImmediate)
+  t.ok(ac.opened, 'a is opened')
+
+  // onclose is a noop here, so `_active` hits 0 synchronously inside `close()`,
+  // which means `_destroy()` (and therefore `ondestroy`) runs immediately
+  ac.close()
+  error = new Error('boom')
+  rejectDestroy(error)
+
+  await new Promise(setImmediate)
+
+  t.absent(streamDestroyed, 'stream was not destroyed after the channel closed')
+})
+
+test.solo('async ondrain rejecting after channel close does not destroy the stream', async function (t) {
+  t.plan(2)
+
+  let error = null
+
+  const a = new Protomux(new SecretStream(true))
+  const b = new Protomux(new SecretStream(false))
+
+  replicate(a, b)
+
+  let streamDestroyed = false
+  b.stream.on('error', function () {
+    t.fail('b stream errored')
+  })
+  b.stream.on('warning', function (err) {
+    t.is(err, error, 'the stream warned the error')
+  })
+  b.stream.on('close', function () {
+    streamDestroyed = true
+  })
+
+  a.createChannel({
+    protocol: 'foo',
+    messages: [{ encoding: c.string }]
+  }).open()
+
+  let rejectDrain = null
+  let handlerReady = null
+  const drained = new Promise((resolve) => {
+    handlerReady = resolve
+  })
+
+  const bc = b.createChannel({
+    protocol: 'foo',
+    messages: [{ encoding: c.string }],
+    ondrain() {
+      return new Promise((_, reject) => {
+        rejectDrain = reject
+        handlerReady()
+      })
+    }
+  })
+  bc.open()
+
+  // force `bc.messages[0].send()` to return false so a future 'drain' event fires
+  while (bc.messages[0].send('hello world')) {
+    // keep sending until backpressure kicks in
+  }
+
+  await drained
+
+  bc.close()
+  error = new Error('boom')
+  rejectDrain(error)
+
+  await new Promise(setImmediate)
+
+  t.absent(streamDestroyed, 'stream was not destroyed after the channel closed')
+})
+
 function replicate(a, b) {
   a.stream.rawStream.pipe(b.stream.rawStream).pipe(a.stream.rawStream)
 }


### PR DESCRIPTION
When a channel is closed, an uncaught promise\'s error is rethrown for the library user to handle. This means that if a user of the library relied on the stream `error` event to catch errors, including those in handlers after a channel is closed, will need to adjust how they catch errors for that edge case. Synchronous errors will continue to emit on the stream and destroy it.

`_decAndDestroy()` was renamed to `_decAndMaybeDestroy()` with an additional flag argument `maybeDestroy` which denotes checking for whether the stream should be destroyed. Two versions of the function are bound and called based on a new flag passed to `_track()` for whether to check if the stream should not be destroyed. This is only used when receiving a message as all other tracked promises should destroy the stream on error (eg close, open, etc).